### PR TITLE
feature/coin-page-view: 코인 페이지 뷰 레이아웃 제작

### DIFF
--- a/frontend/src/components/@layout/CommonLayout.jsx
+++ b/frontend/src/components/@layout/CommonLayout.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { styled } from '@mui/material/styles';
+import { CoinPriceListChart } from '@/components/index';
+// import Sidebar from '@/components/Sidebar/Sidebar';
+
+const CommonMainArticle = styled('article')({
+  position: 'relative',
+  display: 'flex',
+  width: '1400px',
+  margin: '20px auto 0',
+});
+
+const CommonContentsSection = styled('section')({
+  width: '100%',
+  height: '1500px',
+  backgroundColor: '#eee',
+});
+
+const CoinPriceListChartSection = styled('section')({
+  // position: 'fixed',
+  position: 'sticky',
+  top: '0',
+  right: '0',
+  height: '100vh',
+  width: '400px',
+});
+
+function CommonLayout({ children }) {
+  return (
+    <CommonMainArticle>
+      <CommonContentsSection>
+        {children}
+      </CommonContentsSection>
+      <CoinPriceListChartSection>
+        <CoinPriceListChart />
+      </CoinPriceListChartSection>
+      {/* <Sidebar
+        width={400}
+      >
+        <CoinPriceListChart />
+      </Sidebar> */}
+    </CommonMainArticle>
+  );
+}
+
+CommonLayout.propTypes = {
+  children: PropTypes.element.isRequired,
+};
+
+export default CommonLayout;

--- a/frontend/src/components/@layout/CommonLayout.jsx
+++ b/frontend/src/components/@layout/CommonLayout.jsx
@@ -1,49 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// import { styled } from '@mui/material/styles';
-import styled from 'styled-components';
 import { CoinPriceListChart } from '@/components/index';
 import Sidebar from '@/components/Sidebar/Sidebar';
-import { BREAK_POINT } from '@/constants/style';
-
-const CommonMainArticle = styled.article`
-  position: relative;
-  display: block;
-  width: 1400px;
-  margin: 20px auto 0;
-  
-  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
-    display: flex;
-  }
-`;
-
-const CommonContentsSection = styled.section`
-  width: 100%;
-  height: 1500px;
-  backgroundColor: #eee;
-`;
-
-// const CoinPriceListChartSection = styled('section')({
-//   // position: 'fixed',
-//   position: 'sticky',
-//   top: '0',
-//   right: '0',
-//   height: '100vh',
-//   width: '400px',
-// });
-
-const CoinPriceListChartSection = styled.section`
-  display: none;
-  position: sticky;
-  top: 0;
-  right: 0;
-  height: 100vh;
-  width: 400px;
-
-  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
-    display: block;
-  }
-`;
+import {
+  CommonMainArticle,
+  CommonContentsSection,
+  CoinPriceListChartSection,
+} from './CommonLayout.style';
 
 function CommonLayout({ children }) {
   return (

--- a/frontend/src/components/@layout/CommonLayout.jsx
+++ b/frontend/src/components/@layout/CommonLayout.jsx
@@ -1,30 +1,49 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '@mui/material/styles';
+// import { styled } from '@mui/material/styles';
+import styled from 'styled-components';
 import { CoinPriceListChart } from '@/components/index';
-// import Sidebar from '@/components/Sidebar/Sidebar';
+import Sidebar from '@/components/Sidebar/Sidebar';
+import { BREAK_POINT } from '@/constants/style';
 
-const CommonMainArticle = styled('article')({
-  position: 'relative',
-  display: 'flex',
-  width: '1400px',
-  margin: '20px auto 0',
-});
+const CommonMainArticle = styled.article`
+  position: relative;
+  display: block;
+  width: 1400px;
+  margin: 20px auto 0;
+  
+  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
+    display: flex;
+  }
+`;
 
-const CommonContentsSection = styled('section')({
-  width: '100%',
-  height: '1500px',
-  backgroundColor: '#eee',
-});
+const CommonContentsSection = styled.section`
+  width: 100%;
+  height: 1500px;
+  backgroundColor: #eee;
+`;
 
-const CoinPriceListChartSection = styled('section')({
-  // position: 'fixed',
-  position: 'sticky',
-  top: '0',
-  right: '0',
-  height: '100vh',
-  width: '400px',
-});
+// const CoinPriceListChartSection = styled('section')({
+//   // position: 'fixed',
+//   position: 'sticky',
+//   top: '0',
+//   right: '0',
+//   height: '100vh',
+//   width: '400px',
+// });
+
+const CoinPriceListChartSection = styled.section`
+  display: none;
+  position: sticky;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 400px;
+
+  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
+    display: block;
+  }
+`;
 
 function CommonLayout({ children }) {
   return (
@@ -35,11 +54,11 @@ function CommonLayout({ children }) {
       <CoinPriceListChartSection>
         <CoinPriceListChart />
       </CoinPriceListChartSection>
-      {/* <Sidebar
+      <Sidebar
         width={400}
       >
         <CoinPriceListChart />
-      </Sidebar> */}
+      </Sidebar>
     </CommonMainArticle>
   );
 }

--- a/frontend/src/components/@layout/CommonLayout.style.js
+++ b/frontend/src/components/@layout/CommonLayout.style.js
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import { BREAK_POINT } from '@/constants/style';
+
+export const CommonMainArticle = styled.article`
+  position: relative;
+  display: block;
+  width: 1400px;
+  margin: 20px auto 0;
+
+  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
+    display: flex;
+  }
+`;
+
+export const CommonContentsSection = styled.section`
+  width: 100%;
+  height: 1500px;
+  backgroundcolor: #eee;
+`;
+
+export const CoinPriceListChartSection = styled.section`
+  display: none;
+  position: sticky;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 400px;
+
+  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
+    display: block;
+  }
+`;

--- a/frontend/src/components/CoinPriceListChart/CoinPriceListChart.style.js
+++ b/frontend/src/components/CoinPriceListChart/CoinPriceListChart.style.js
@@ -4,6 +4,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 
 export const CoinPriceListContainer = styled('article')({
+  width: '400px',
   height: '100vh',
   padding: '10px',
   boxShadow: '2px 2px 4px #dee1e7',

--- a/frontend/src/components/CoinPriceListChart/CoinPriceListChart.style.js
+++ b/frontend/src/components/CoinPriceListChart/CoinPriceListChart.style.js
@@ -4,10 +4,11 @@ import CloseIcon from '@mui/icons-material/Close';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 
 export const CoinPriceListContainer = styled('article')({
-  width: '400px',
-  height: '100%',
+  height: '100vh',
   padding: '10px',
   boxShadow: '2px 2px 4px #dee1e7',
+  border: '1px solid #eee',
+  backgroundColor: '#fff',
 });
 
 export const CoinSearchContainer = styled('div')({

--- a/frontend/src/components/Sidebar/Sidebar.jsx
+++ b/frontend/src/components/Sidebar/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { BREAK_POINT } from '@/constants/style';
 
 const SidebarContainer = styled.section`
   display: flex;
@@ -9,6 +10,10 @@ const SidebarContainer = styled.section`
   right: 0;
   transform: ${({ position }) => `translateX(${position}px)`};
   transition: 0.3s ease;
+
+  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
+    display: none;
+  }
 `;
 
 const ToggleButton = styled.button`
@@ -19,7 +24,8 @@ const ToggleButton = styled.button`
   position: fixed;
   left: -74px;
   transform: rotate(-90deg);
-  visibility: ${({ isSidebar }) => (isSidebar ? 'hidden' : 'visible')};
+  display: ${({ isSidebar }) => (isSidebar ? 'none' : 'block')};
+  transition: 0.5s ease;
 `;
 
 function Sidebar({ children, width }) {

--- a/frontend/src/components/Sidebar/Sidebar.jsx
+++ b/frontend/src/components/Sidebar/Sidebar.jsx
@@ -1,32 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { BREAK_POINT } from '@/constants/style';
-
-const SidebarContainer = styled.section`
-  display: flex;
-  position: fixed;
-  top: 0;
-  right: 0;
-  transform: ${({ position }) => `translateX(${position}px)`};
-  transition: 0.3s ease;
-
-  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
-    display: none;
-  }
-`;
-
-const ToggleButton = styled.button`
-  width: 98px;
-  padding: 0;
-  margin: 0;
-  top: 50%;
-  position: fixed;
-  left: -74px;
-  transform: rotate(-90deg);
-  display: ${({ isSidebar }) => (isSidebar ? 'none' : 'block')};
-  transition: 0.3s ease;
-`;
+import {
+  SidebarContainer,
+  ToggleButton,
+} from './Sidebar.style';
 
 function Sidebar({ children, width }) {
   const [position, setPosition] = useState(width);

--- a/frontend/src/components/Sidebar/Sidebar.jsx
+++ b/frontend/src/components/Sidebar/Sidebar.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const SidebarContainer = styled.section`
+  display: flex;
+  position: fixed;
+  top: 0;
+  right: 0;
+  transform: ${({ position }) => `translateX(${position}px)`};
+  transition: 0.3s ease;
+`;
+
+const ToggleButton = styled.button`
+  width: 98px;
+  padding: 0;
+  margin: 0;
+  top: 50%;
+  position: fixed;
+  left: -74px;
+  transform: rotate(-90deg);
+  visibility: ${({ isSidebar }) => (isSidebar ? 'hidden' : 'visible')};
+`;
+
+function Sidebar({ children, width }) {
+  const [position, setPosition] = useState(width);
+  const [isSidebar, setIsSidebar] = useState(false);
+
+  const toggleMenu = () => {
+    if (position > 0) {
+      setPosition(0);
+      setIsSidebar(true);
+      return;
+    }
+    setPosition(width);
+    setIsSidebar(false);
+  };
+
+  return (
+    <SidebarContainer
+      position={position}
+    >
+      <ToggleButton
+        type="button"
+        onMouseEnter={() => toggleMenu()}
+        isSidebar={isSidebar}
+      >
+        CoinPrice
+      </ToggleButton>
+      <div
+        onMouseLeave={() => toggleMenu()}
+      >
+        {children}
+      </div>
+    </SidebarContainer>
+  );
+}
+
+Sidebar.propTypes = {
+  children: PropTypes.element.isRequired,
+  width: PropTypes.number.isRequired,
+};
+
+export default Sidebar;

--- a/frontend/src/components/Sidebar/Sidebar.jsx
+++ b/frontend/src/components/Sidebar/Sidebar.jsx
@@ -25,7 +25,7 @@ const ToggleButton = styled.button`
   left: -74px;
   transform: rotate(-90deg);
   display: ${({ isSidebar }) => (isSidebar ? 'none' : 'block')};
-  transition: 0.5s ease;
+  transition: 0.3s ease;
 `;
 
 function Sidebar({ children, width }) {
@@ -39,7 +39,8 @@ function Sidebar({ children, width }) {
       return;
     }
     setPosition(width);
-    setIsSidebar(false);
+
+    setTimeout(() => setIsSidebar(false), 400);
   };
 
   return (

--- a/frontend/src/components/Sidebar/Sidebar.style.js
+++ b/frontend/src/components/Sidebar/Sidebar.style.js
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { BREAK_POINT } from '@/constants/style';
+
+export const SidebarContainer = styled.section`
+  display: flex;
+  position: fixed;
+  top: 0;
+  right: 0;
+  transform: ${({ position }) => `translateX(${position}px)`};
+  transition: 0.3s ease;
+
+  @media only screen and (min-width: ${BREAK_POINT.LG}px) {
+    display: none;
+  }
+`;
+
+export const ToggleButton = styled.button`
+  width: 98px;
+  padding: 0;
+  margin: 0;
+  top: 50%;
+  position: fixed;
+  left: -60px;
+  transform: rotate(-90deg);
+  display: ${({ isSidebar }) => (isSidebar ? 'none' : 'block')};
+  transition: 0.3s ease;
+`;

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,3 +1,3 @@
 export { default as PostCard } from './PostCard/PostCard';
-export { default as MenuBar } from './menuBar/MenuBar';
+export { default as MenuBar } from './MenuBar/MenuBar';
 export { default as CoinPriceListChart } from './CoinPriceListChart/CoinPriceListChart';

--- a/frontend/src/constants/style.js
+++ b/frontend/src/constants/style.js
@@ -18,7 +18,7 @@ export const ORAGNE = Object.freeze({
   // https://mui.com/customization/color/#main-content
 });
 
-export const BREAT_POINT = Object.freeze({
+export const BREAK_POINT = Object.freeze({
   SM: 600,
   MD: 768,
   LG: 992,

--- a/frontend/src/constants/style.js
+++ b/frontend/src/constants/style.js
@@ -17,3 +17,10 @@ export const ORAGNE = Object.freeze({
   900: '#e65100',
   // https://mui.com/customization/color/#main-content
 });
+
+export const BREAT_POINT = Object.freeze({
+  SM: 600,
+  MD: 768,
+  LG: 992,
+  XL: 1200,
+});

--- a/frontend/src/globalStyle.style.js
+++ b/frontend/src/globalStyle.style.js
@@ -15,7 +15,6 @@ const GlobalStyle = () => (
       body,
       #root {
         width: 100%;
-        height: 100%;
         font-size: 16px;
       }
 

--- a/frontend/src/pages/CoinInfoPage/CoinInfoPage.jsx
+++ b/frontend/src/pages/CoinInfoPage/CoinInfoPage.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import CommonLayout from '@/components/@layout/CommonLayout';
+// import { styled } from '@mui/material/styles';
+// import { CoinPriceListChart } from '@/components/index';
+
+// const CoinInfoArticle = styled('article')({
+//   position: 'relative',
+//   display: 'flex',
+// });
+
+// const CoinCandleStickChartSection = styled('section')({
+//   width: '990px',
+//   height: '1500px',
+// });
+
+// const CoinPriceListChartSection = styled('section')({
+//   position: 'sticky',
+//   top: '0',
+//   height: '100vh',
+// });
+
+/*
+<CoinInfoArticle>
+  <CoinCandleStickChartSection>
+    <p>차트 영역</p>
+  </CoinCandleStickChartSection>
+  <CoinPriceListChartSection>
+    <CoinPriceListChart />
+  </CoinPriceListChartSection>
+</CoinInfoArticle>
+*/
+
+function CoinInfoPage() {
+  return (
+    <>
+      <CommonLayout>
+        <p>제발...!!!</p>
+      </CommonLayout>
+    </>
+  );
+}
+
+export default CoinInfoPage;

--- a/frontend/src/pages/HomeMainPage/HomeMainPage.jsx
+++ b/frontend/src/pages/HomeMainPage/HomeMainPage.jsx
@@ -1,6 +1,10 @@
+import CommonLayout from '@/components/@layout/CommonLayout';
+
 const HomeMainPage = () => (
   <>
-    mainpage 입니다.
+    <CommonLayout>
+      여기에 컴포넌트 추가해주세요
+    </CommonLayout>
   </>
 );
 

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -2,3 +2,4 @@ export { default as HomeMainPage } from './HomeMainPage/HomeMainPage';
 export { default as LoginPage } from './LoginPage/LoginPage';
 export { default as MyPage } from './MyPage/MyPage';
 export { default as NotFound } from './NotFound/NotFound';
+export { default as CoinInfoPage } from './CoinInfoPage/CoinInfoPage';

--- a/frontend/src/router/Router.jsx
+++ b/frontend/src/router/Router.jsx
@@ -1,7 +1,12 @@
 import { Route, Switch } from 'react-router-dom';
 import {
-  HomeMainPage, LoginPage, MyPage, NotFound,
+  CoinInfoPage,
+  HomeMainPage,
+  LoginPage,
+  MyPage,
+  NotFound,
 } from '@/pages/index';
+import { MenuBar } from '@/components/index';
 import ROUTE from './routePath';
 import PrivateRoute from './PrivateRoute';
 
@@ -22,6 +27,11 @@ const routes = [
     isPrivate: true,
   },
   {
+    path: ROUTE.COIN.PATH,
+    component: <CoinInfoPage />,
+    isPrivate: false,
+  },
+  {
     path: '*',
     component: <NotFound />,
     isPrivate: false,
@@ -34,9 +44,24 @@ const RouteComponent = routes.map(({ path, component, isPrivate }) => (
     : <PrivateRoute key={path} exact path={path}>{component}</PrivateRoute>));
 
 const Router = () => (
-  <Switch>
-    {RouteComponent}
-  </Switch>
+  <>
+    <Switch>
+      <Route
+        exact
+        path={
+        [
+          ROUTE.MAIN.PATH,
+          ROUTE.COIN.PATH,
+        ]
+      }
+      >
+        <MenuBar />
+      </Route>
+    </Switch>
+    <Switch>
+      {RouteComponent}
+    </Switch>
+  </>
 );
 
 export default Router;

--- a/frontend/src/router/routePath.js
+++ b/frontend/src/router/routePath.js
@@ -8,6 +8,9 @@ const ROUTE = Object.freeze({
   MYPAGE: {
     PATH: '/mypage/:username',
   },
+  COIN: {
+    PATH: '/coin/:coinname',
+  },
 });
 
 export default ROUTE;


### PR DESCRIPTION
* 공통 레이아웃 제작
* 기기 Viewport에 따른 반응형 구현(992px 기준)
* Sidebar 구현

# 특이사항
* 992px 이상일 경우 오른쪽 사이드에 실시간 코인 리스트 차트가 sticky로 항상 보여짐
* 992px 이하일 경우 실시간 코인 리스트 차트가 Sidebar로 이동
* 세부적인 레이아웃은 의논을 통해 조정 필요

# Todo
* 코인 리스트 차트 width 조절
* Sidebar 버튼 디자인